### PR TITLE
Implement an ability of sending messages to the multi-user chat

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -4,13 +4,13 @@ akka {
 }
 
 messaging {
-  domain = "localhost"
-  host = "localhost"
-  service = "conference.localhost"
+  domain = "dev.spring.co.nz"
+  host = "aklvvm022"
+  service = "conference.dev.spring.co.nz"
 
   admin {
-    username = "admin"
-    password = "12345"
+    username = "spring"
+    password = "spring"
   }
 }
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -4,13 +4,13 @@ akka {
 }
 
 messaging {
-  domain = "dev.spring.co.nz"
-  host = "aklvvm022"
-  service = "conference.dev.spring.co.nz"
+  domain = "localhost"
+  host = "localhost"
+  service = "conference.localhost"
 
   admin {
-    username = "spring"
-    password = "spring"
+    username = "admin"
+    password = "12345"
   }
 }
 

--- a/src/test/scala/smack/messaging/ClientTest.scala
+++ b/src/test/scala/smack/messaging/ClientTest.scala
@@ -127,6 +127,14 @@ class ClientTest extends WordSpec with Matchers with BeforeAndAfterEach {
 
       "multi-user chat" that {
         "succeeds" when {
+          "acknowledges delivered groupchat message" in new TestFunctions {
+            groupChatDeliveryAcknowledged
+          }
+
+          "user send message to chatroom" in new TestFunctions {
+            chatRoomMessageSent
+          }
+
           "creating group chatroom" in new TestFunctions {
             createChatRoom
           }
@@ -261,51 +269,59 @@ class ClientTest extends WordSpec with Matchers with BeforeAndAfterEach {
         }
       }
 
-     "multi-user chat" that {
-       "succeeds" when {
-         "creating group chatroom" in new TestFunctionsWithDomain {
-           createChatRoom
-         }
+      "multi-user chat" that {
+        "succeeds" when {
+          "acknowledges delivered groupchat message" in new TestFunctions {
+            groupChatDeliveryAcknowledged
+          }
 
-         "member joins room" in new TestFunctionsWithDomain {
-           memberJoin
-         }
+          "user send message to chatroom" in new TestFunctions {
+            chatRoomMessageSent
+          }
 
-         "admin removes member" in new TestFunctionsWithDomain {
-           removeMember
-         }
+          "creating group chatroom" in new TestFunctionsWithDomain {
+            createChatRoom
+          }
 
-         "user gets membership" in new TestFunctionsWithDomain {
-           getMembership
-         }
-       }
+          "member joins room" in new TestFunctionsWithDomain {
+            memberJoin
+          }
 
-       "fails" when {
-         "creating chatroom that already exists" in new TestFunctionsWithDomain {
-           createMultipleChatRooms
-         }
+          "admin removes member" in new TestFunctionsWithDomain {
+            removeMember
+          }
 
-         "non-member tries to join room" in new TestFunctionsWithDomain {
-           failNonMember
-         }
+          "user gets membership" in new TestFunctionsWithDomain {
+            getMembership
+          }
+        }
 
-         "non admin tries to accept member" in new TestFunctionsWithDomain {
-           nonAdminMemberFail
-         }
+        "fails" when {
+          "creating chatroom that already exists" in new TestFunctionsWithDomain {
+            createMultipleChatRooms
+          }
 
-         "user tries to join with same nickname" in new TestFunctionsWithDomain {
-           sameNickname
-         }
+          "non-member tries to join room" in new TestFunctionsWithDomain {
+            failNonMember
+          }
 
-         "non admin tries to remove member" in new TestFunctionsWithDomain {
-           nonAdminRemoveFail
-         }
+          "non admin tries to accept member" in new TestFunctionsWithDomain {
+            nonAdminMemberFail
+          }
 
-         "user tries to get membership when not part of group" in new TestFunctionsWithDomain {
-           forbiddenMembership
-         }
-       }
-     }
+          "user tries to join with same nickname" in new TestFunctionsWithDomain {
+            sameNickname
+          }
+
+          "non admin tries to remove member" in new TestFunctionsWithDomain {
+            nonAdminRemoveFail
+          }
+
+          "user tries to get membership when not part of group" in new TestFunctionsWithDomain {
+            forbiddenMembership
+          }
+        }
+      }
     }
   }
 
@@ -391,9 +407,8 @@ class ClientTest extends WordSpec with Matchers with BeforeAndAfterEach {
 
         user1 ! SendMessage(username2, testMessage)
 
-        // yeah, sleeping is bad, but I dunno how else to make this guaranteed async.
-        Thread.sleep(1000)
-        user2 ! Connect(username2, user2Pass)
+        val connectionTimeout = 1.second
+        Await.result(user2 ? Connect(username2, user2Pass), connectionTimeout)
 
         verifyMessageArrived(user2Listener, username1, username2, testMessage)
       }
@@ -489,6 +504,22 @@ class ClientTest extends WordSpec with Matchers with BeforeAndAfterEach {
       }
     }
 
+    def chatRoomMessageSent = {
+      withChatRoomMembers {
+        user1 ? SendMultiUserMessage(chatRoom, testMessage)
+        verifyGroupMessageArrived(user2Listener, username2, chatRoom, testMessage)
+        verifyGroupMessageArrived(user1Listener, username1, chatRoom, testMessage)
+      }
+    }
+
+    def groupChatDeliveryAcknowledged = {
+      withChatRoomMembers {
+        val user1MessageId = user1 ? SendMultiUserMessage(chatRoom, testMessage)
+        verifyGroupMessageArrived(user1Listener, username1, chatRoom, testMessage)
+        verifyGroupMessageDelivery(user1Listener, chatRoom, username1, user1MessageId)
+      }
+    }
+
     def deliveryAcknowledged = {
       withTwoConnectedUsers {
         val user1MessageId = user1 ? SendMessage(username2, testMessage)
@@ -505,9 +536,8 @@ class ClientTest extends WordSpec with Matchers with BeforeAndAfterEach {
 
         val user1MessageId = user1 ? SendMessage(username2, testMessage)
 
-        // yeah, sleeping is bad, but I dunno how else to make this guaranteed async.
-        Thread.sleep(1000)
-        user2 ! Connect(username2, user2Pass)
+        val connectionTimeout = 1.second
+        Await.result(user2 ? Connect(username2, user2Pass), connectionTimeout)
 
         verifyMessageArrived(user2Listener, username1, username2, testMessage)
         verifyMessageDelivery(user1Listener, username1, username2, user1MessageId)
@@ -531,9 +561,8 @@ class ClientTest extends WordSpec with Matchers with BeforeAndAfterEach {
             ids(0).id shouldBe user1MessageId
         }
 
-        // yeah, sleeping is bad, but I dunno how else to make this guaranteed async.
-        Thread.sleep(1000)
-        user2 ! Connect(username2, user2Pass)
+        val connectionTimeout = 1.second
+        Await.result(user2 ? Connect(username2, user2Pass), connectionTimeout)
 
         verifyMessageArrived(user2Listener, username1, username2, testMessage)
         verifyMessageDelivery(user1Listener, username1, username2, user1MessageIdFuture)
@@ -848,6 +877,32 @@ class ClientTest extends WordSpec with Matchers with BeforeAndAfterEach {
       }
     }
 
+    def withChatRoomMembers(block: => Unit) = {
+      withChatRoom() {
+        withTwoConnectedUsers {
+          adminUser ? RegisterChatRoomMembership(chatRoom, username1)
+          user1 ? ChatRoomJoin(chatRoom, username1Nickname)
+
+          adminUser ? RegisterChatRoomMembership(chatRoom, username2)
+          user2 ? ChatRoomJoin(chatRoom, username2Nickname)
+
+          block
+        }
+      }
+    }
+
+    def verifyGroupMessageArrived(testProbe: TestProbe, sender: User, recipient: ChatRoom, messageBody: String): Unit = {
+      testProbe.fishForMessage(timeout.duration, "expected message to be delivered") {
+        case GroupChatMessageReceived(chat, message) ⇒
+          chat.value should startWith(recipient.value)
+          message.getFrom should startWith(recipient.value)
+          message.getTo should startWith(sender.value)
+          message.getBody shouldBe messageBody
+          true
+        case _ ⇒ false
+      }
+    }
+
     def verifyMessageArrived(testProbe: TestProbe, sender: User, recipient: User, messageBody: String): Unit = {
       testProbe.fishForMessage(timeout.duration, "expected message to be delivered") {
         case MessageReceived(chat, message) ⇒
@@ -856,6 +911,20 @@ class ClientTest extends WordSpec with Matchers with BeforeAndAfterEach {
           message.getBody shouldBe messageBody
           true
         case _ ⇒ false
+      }
+    }
+
+    def verifyGroupMessageDelivery(testProbe: TestProbe, chatRoom: Client.ChatRoom, user: Client.User,
+                                   messageIdFuture: Future[Any]): Unit = {
+      testProbe.fishForMessage(timeout.duration, "notification that message has been delivered to the group chat") {
+        case GroupChatMessageDelivered(chat, msgId) ⇒
+          Await.result(messageIdFuture, timeout.duration) match {
+            case MessageId(messageId) ⇒
+              messageId should equal(msgId.getStanzaId)
+          }
+          true
+
+        case e ⇒ false
       }
     }
 

--- a/src/test/scala/smack/messaging/ClientTest.scala
+++ b/src/test/scala/smack/messaging/ClientTest.scala
@@ -269,59 +269,59 @@ class ClientTest extends WordSpec with Matchers with BeforeAndAfterEach {
         }
       }
 
-      "multi-user chat" that {
-        "succeeds" when {
-          "acknowledges delivered groupchat message" in new TestFunctions {
-            groupChatDeliveryAcknowledged
-          }
+     "multi-user chat" that {
+       "succeeds" when {
+         "acknowledges delivered groupchat message" in new TestFunctions {
+           groupChatDeliveryAcknowledged
+         }
 
-          "user send message to chatroom" in new TestFunctions {
-            chatRoomMessageSent
-          }
+         "user send message to chatroom" in new TestFunctions {
+           chatRoomMessageSent
+         }
 
-          "creating group chatroom" in new TestFunctionsWithDomain {
-            createChatRoom
-          }
+         "creating group chatroom" in new TestFunctionsWithDomain {
+           createChatRoom
+         }
 
-          "member joins room" in new TestFunctionsWithDomain {
-            memberJoin
-          }
+         "member joins room" in new TestFunctionsWithDomain {
+           memberJoin
+         }
 
-          "admin removes member" in new TestFunctionsWithDomain {
-            removeMember
-          }
+         "admin removes member" in new TestFunctionsWithDomain {
+           removeMember
+         }
 
-          "user gets membership" in new TestFunctionsWithDomain {
-            getMembership
-          }
-        }
+         "user gets membership" in new TestFunctionsWithDomain {
+           getMembership
+         }
+       }
 
-        "fails" when {
-          "creating chatroom that already exists" in new TestFunctionsWithDomain {
-            createMultipleChatRooms
-          }
+       "fails" when {
+         "creating chatroom that already exists" in new TestFunctionsWithDomain {
+           createMultipleChatRooms
+         }
 
-          "non-member tries to join room" in new TestFunctionsWithDomain {
-            failNonMember
-          }
+         "non-member tries to join room" in new TestFunctionsWithDomain {
+           failNonMember
+         }
 
-          "non admin tries to accept member" in new TestFunctionsWithDomain {
-            nonAdminMemberFail
-          }
+         "non admin tries to accept member" in new TestFunctionsWithDomain {
+           nonAdminMemberFail
+         }
 
-          "user tries to join with same nickname" in new TestFunctionsWithDomain {
-            sameNickname
-          }
+         "user tries to join with same nickname" in new TestFunctionsWithDomain {
+           sameNickname
+         }
 
-          "non admin tries to remove member" in new TestFunctionsWithDomain {
-            nonAdminRemoveFail
-          }
+         "non admin tries to remove member" in new TestFunctionsWithDomain {
+           nonAdminRemoveFail
+         }
 
-          "user tries to get membership when not part of group" in new TestFunctionsWithDomain {
-            forbiddenMembership
-          }
-        }
-      }
+         "user tries to get membership when not part of group" in new TestFunctionsWithDomain {
+           forbiddenMembership
+         }
+       }
+     }
     }
   }
 


### PR DESCRIPTION
Before these changes, it was impossible to send message in address of room/group. 

This PR is intended to improve situation by applying minor changes to the `smack.scala.Client` and introducing a new message type - `Messages.SendMultiUserMessage(room, message)`.
